### PR TITLE
expandvars 1.1.2: Rebuild for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pretend-feedstock/pr2/b07d20f
-  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr16/239c2c5
-  - https://staging.continuum.io/pbp/fs/hatchling-feedstock/pr9/f1bef63

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,7 @@
-aggregate_check: false
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pretend-feedstock/pr2/b07d20f
+  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr16/239c2c5
+  - https://staging.continuum.io/pbp/fs/hatchling-feedstock/pr9/f1bef63

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   skip: true  # [py<36]
 
 requirements:


### PR DESCRIPTION
**Destination channel:** main

### Links

- []()
- [Upstream repo](https://github.com/sayanarijit/expandvars/tree/v1.1.2)
- requirements-tagged: https://github.com/sayanarijit/expandvars/blob/v1.1.2/pyproject.toml


### Explanation of changes:

- Bump a build number to 1
- Add `ANACONDA_ROCKET_ENABLE_PY314 : yes` to `abs.yaml`